### PR TITLE
Send all uwsgi metrics in one batch

### DIFF
--- a/plugin.c
+++ b/plugin.c
@@ -89,6 +89,7 @@ static void influxdb_send_metrics(struct uwsgi_buffer *ub, const char *url) {
 	if (http_code != 204) {
 		uwsgi_log_verbose("[influxdb] HTTP api returned non-200 response code: %d\n", (int) http_code);
 	}
+	curl_easy_cleanup(curl);
 }
 
 /*


### PR DESCRIPTION
This batches all the uwsgi metrics into one buffer and sends in a single curl http request, massively reducing the number of tcp handshakes necessary.